### PR TITLE
fix: SecurityContext에 User 주입 및 조회하도록 수정

### DIFF
--- a/src/main/java/com/aptzip/common/config/jwt/TokenProvider.java
+++ b/src/main/java/com/aptzip/common/config/jwt/TokenProvider.java
@@ -64,7 +64,6 @@ public class TokenProvider {
         String uuid = claims.get("id", String.class);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
 
-        // ✅ User 엔티티 직접 생성 (DB 조회 없이 최소 정보만)
         User user = User.builder()
                 .userUuid(uuid)
                 .email(email)

--- a/src/main/java/com/aptzip/common/config/jwt/TokenProvider.java
+++ b/src/main/java/com/aptzip/common/config/jwt/TokenProvider.java
@@ -60,9 +60,18 @@ public class TokenProvider {
     // 토큰 기반으로 인증 정보를 가져오는 메서드
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
+        String email = claims.getSubject();
+        String uuid = claims.get("id", String.class);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
 
-        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
+        // ✅ User 엔티티 직접 생성 (DB 조회 없이 최소 정보만)
+        User user = User.builder()
+                .userUuid(uuid)
+                .email(email)
+                .password("")
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(user, token, authorities);
     }
 
     // 토큰 기반으로 유저 ID를 가져오는 메서드

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -41,9 +41,9 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/update/profileUrl/{userUuid}")
-    public ResponseEntity<Void> updateProfileUrl(@PathVariable("userUuid") String userUuid, @RequestBody UpdateProfileUrlRequest updateProfileUrlRequest) {
-        userService.updateProfileUrl(userUuid, updateProfileUrlRequest);
+    @PutMapping("/update/profileUrl")
+    public ResponseEntity<Void> updateProfileUrl(@AuthenticationPrincipal User user, @RequestBody UpdateProfileUrlRequest updateProfileUrlRequest) {
+        userService.updateProfileUrl(user.getUserUuid(), updateProfileUrlRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -47,9 +47,9 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/delete/{userUuid}")
-    public ResponseEntity<Void> withdrawUser(@PathVariable String userUuid) {
-        userService.withdrawUser(userUuid);
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> withdrawUser(@AuthenticationPrincipal User user) {
+        userService.withdrawUser(user.getUserUuid());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -6,14 +6,10 @@ import com.aptzip.user.dto.request.UpdateUserRequest;
 import com.aptzip.user.dto.response.UserDetailResponse;
 import com.aptzip.user.entity.User;
 import com.aptzip.user.service.UserService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -4,12 +4,14 @@ import com.aptzip.user.dto.request.AddUserRequest;
 import com.aptzip.user.dto.request.UpdateProfileUrlRequest;
 import com.aptzip.user.dto.request.UpdateUserRequest;
 import com.aptzip.user.dto.response.UserDetailResponse;
+import com.aptzip.user.entity.User;
 import com.aptzip.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
@@ -28,9 +30,9 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/detail/{userUuid}")
-    public ResponseEntity<UserDetailResponse> userDetail(@PathVariable("userUuid") String userUuid) {
-        return ResponseEntity.ok(userService.findByUuid(userUuid));
+    @GetMapping("/detail")
+    public ResponseEntity<UserDetailResponse> userDetail(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(userService.findByUuid(user.getUserUuid()));
     }
 
     @PutMapping("/update/profile/{userUuid}")

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -35,9 +35,9 @@ public class UserController {
         return ResponseEntity.ok(userService.findByUuid(user.getUserUuid()));
     }
 
-    @PutMapping("/update/profile/{userUuid}")
-    public ResponseEntity<Void> updateUser(@PathVariable("userUuid") String userUuid, @RequestBody UpdateUserRequest updateUserRequest) {
-        userService.updateUser(userUuid, updateUserRequest);
+    @PutMapping("/update/profile")
+    public ResponseEntity<Void> updateUser(@AuthenticationPrincipal User user, @RequestBody UpdateUserRequest updateUserRequest) {
+        userService.updateUser(user.getUserUuid(), updateUserRequest);
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
### 중요 변경 사항 🚨

> 하기 사항이 변경된 경우 체크해주세요.

- [ ] DB 스키마가 수정되었습니다.
- [ ] 환경변수 파일이 추가/삭제/수정되었습니다.
- [ ] 의존성이 추가/삭제/수정되었습니다.

### 작업 내용 🧑🏻‍💻

> 기능 추가, 버그 수정 등 작업 내용을 작성해주세요.

- SecurityContext에 User 주입되도록 인증 객체를 수정하였습니다.
- SecurityContext에서 userUuid를 가져오도록 다음의 API를 수정하였습니다.
  - 회원정보 조회 API
  - 회원정보 수정 API
  - 프로필 사진 url 수정 API
  - 회원탈퇴 API

### 관련 이슈

> 본 PR이 머지되면 자동으로 닫을 이슈를 [형식](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)에 따라 작성하고,
> 종료하지 않고 연결만 한다면 예약어 없이 작성해주세요.

- close #18 
