### PR TITLE
fix: 모든 서버 예외 401 Unauthorized 반환 문제 수정

### DIFF
--- a/src/main/java/com/aptzip/auth/dto/request/SigninRequest.java
+++ b/src/main/java/com/aptzip/auth/dto/request/SigninRequest.java
@@ -2,6 +2,5 @@ package com.aptzip.auth.dto.request;
 
 public record SigninRequest(
         String email,
-        String password
-) {
+        String password) {
 }

--- a/src/main/java/com/aptzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/aptzip/common/config/WebSecurityConfig.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -23,11 +22,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 @Configuration
 @EnableWebSecurity
@@ -62,7 +57,6 @@ public class WebSecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
-//                .requestMatchers(toH2Console())
                 .requestMatchers("/img/**", "/css/**", "/js/**");
     }
 

--- a/src/main/java/com/aptzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/aptzip/common/config/WebSecurityConfig.java
@@ -8,16 +8,19 @@ import com.aptzip.common.config.jwt.JwtProperties;
 import com.aptzip.common.config.jwt.TokenProvider;
 import com.aptzip.common.filter.TokenAuthenticationFilter;
 import com.aptzip.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -66,6 +69,7 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -89,7 +93,6 @@ public class WebSecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .loginPage("/login")
                         .authorizationEndpoint(endpoint -> endpoint
                                 .authorizationRequestRepository(authorizationRequestRepository())
                         )
@@ -99,10 +102,15 @@ public class WebSecurityConfig {
                         .successHandler(oAuth2SuccessHandler())
                 )
                 .exceptionHandling(ex -> ex
-                        .defaultAuthenticationEntryPointFor(
-                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
-                                new AntPathRequestMatcher("/api/**")
-                        )
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            if (authException instanceof AuthenticationException) {
+                                // 인증 실패만 401
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+                            } else {
+                                // 그 외는 ControllerAdvice로
+                                throw authException;
+                            }
+                        })
                 )
                 .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/aptzip/common/config/cors/CorsConfig.java
+++ b/src/main/java/com/aptzip/common/config/cors/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.aptzip.common.config;
+package com.aptzip.common.config.cors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/aptzip/common/config/cors/CorsProperties.java
+++ b/src/main/java/com/aptzip/common/config/cors/CorsProperties.java
@@ -1,4 +1,4 @@
-package com.aptzip.common.config;
+package com.aptzip.common.config.cors;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/aptzip/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/aptzip/common/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.aptzip.common.config;
+package com.aptzip.common.config.redis;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/aptzip/common/config/redis/RedisProperties.java
+++ b/src/main/java/com/aptzip/common/config/redis/RedisProperties.java
@@ -1,4 +1,4 @@
-package com.aptzip.common.config;
+package com.aptzip.common.config.redis;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/aptzip/common/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/aptzip/common/filter/TokenAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -24,19 +25,28 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
 
-        // 요청 헤더의 Authorization 키의 값 조회
-        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-        // 가져온 값에서 접두사 제거
-        String token = getAccessToken(authorizationHeader);
-        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
-        if(tokenProvider.validToken(token)) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            String userUuid = tokenProvider.getUserId(token);
-            request.setAttribute("userUuid", userUuid);
-        }
+        try {
+            // 요청 헤더의 Authorization 키의 값 조회
+            String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+            // 가져온 값에서 접두사 제거
+            String token = getAccessToken(authorizationHeader);
+            // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
+            if (tokenProvider.validToken(token)) {
+                Authentication authentication = tokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                String userUuid = tokenProvider.getUserId(token);
+                request.setAttribute("userUuid", userUuid);
+            }
 
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException | ServletException | IOException authEx) {
+            // 인증·서블릿 오류는 그대로 다시 던져서 EntryPoint로 보냄
+            throw authEx;
+
+        } catch (Exception ex) {
+            // 그 외(비즈니스, DB 제약 위반 등)는 Spring MVC (@ControllerAdvice)로
+            throw ex;
+        }
     }
 
     private String getAccessToken(String authorizationHeader) {

--- a/src/main/java/com/aptzip/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/aptzip/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.aptzip.common.handler;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<?> handleConflict(DataIntegrityViolationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT) // 409
+                .body(Map.of("message", "이미 존재하는 데이터입니다."));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleBadRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST) // 400
+                .body(Map.of("message", e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleAll(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR) // 500
+                .body(Map.of("message", "서버 오류 발생", "error", e.getClass().getSimpleName()));
+    }
+}

--- a/src/main/java/com/aptzip/user/controller/UserController.java
+++ b/src/main/java/com/aptzip/user/controller/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(AddUserRequest addUserRequest) {
+    public ResponseEntity<Void> signup(@RequestBody AddUserRequest addUserRequest) {
         userService.save(addUserRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/aptzip/user/repository/UserRepository.java
+++ b/src/main/java/com/aptzip/user/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByUserUuid(String uuid);
+    Optional<User> findById(String uuid);
 }

--- a/src/main/java/com/aptzip/user/service/UserService.java
+++ b/src/main/java/com/aptzip/user/service/UserService.java
@@ -27,18 +27,8 @@ public class UserService {
         return userRepository.save(user).getUserUuid();
     }
 
-    public User findById(String userUuid) {
-        return userRepository.findById(userUuid)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
-    }
-
-    public User findByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
-    }
-
     public UserDetailResponse findByUuid(String userUuid) {
-        User user = userRepository.findByUserUuid(userUuid)
+        User user = userRepository.findById(userUuid)
                 .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
 
         return new UserDetailResponse(
@@ -51,7 +41,7 @@ public class UserService {
 
     @Transactional
     public void updateUser(String userUuid, UpdateUserRequest updateUserRequest) {
-        User user = userRepository.findByUserUuid(userUuid)
+        User user = userRepository.findById(userUuid)
                 .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
 
         String encodedPassword = null;
@@ -68,7 +58,7 @@ public class UserService {
 
     @Transactional
     public void updateProfileUrl(String userUuid, UpdateProfileUrlRequest updateProfileUrlRequest) {
-        User user = userRepository.findByUserUuid(userUuid)
+        User user = userRepository.findById(userUuid)
                 .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
 
         user.updateProfileUrl(updateProfileUrlRequest.profileUrl());
@@ -76,7 +66,7 @@ public class UserService {
 
     @Transactional
     public void withdrawUser(String userUuid) {
-        User user = userRepository.findByUserUuid(userUuid)
+        User user = userRepository.findById(userUuid)
                 .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
 
         userRepository.delete(user);

--- a/src/main/java/com/aptzip/user/service/UserService.java
+++ b/src/main/java/com/aptzip/user/service/UserService.java
@@ -18,10 +18,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
-    public String save(AddUserRequest dto) {
+    public String save(AddUserRequest addUserRequest) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
-        User user = dto.toEntity();
+        User user = addUserRequest.toEntity();
         user.encodePassword(encoder);
 
         return userRepository.save(user).getUserUuid();


### PR DESCRIPTION
### 중요 변경 사항 🚨

> 하기 사항이 변경된 경우 체크해주세요.

- [ ] DB 스키마가 수정되었습니다.
- [ ] 환경변수 파일이 추가/삭제/수정되었습니다.
- [ ] 의존성이 추가/삭제/수정되었습니다.

### 작업 내용 🧑🏻‍💻

> 기능 추가, 버그 수정 등 작업 내용을 작성해주세요.

-  모든 서버 예외가 `401 Unauthorized`로 반환되는 문제를 수정하였습니다.
- `TokenAuthenticationFilter`에 `try catch`문을 적용하였습니다.
- 인증 실패시에만 `401`이 반환되도록 `WebSecurityConfig`에 분기처리를 하였습니다.
- OAuth2에서 리다이렉트 url이 아닌 상태코드가 반환되도록 `WebSecurityConfig`를 수정하였습니다.
- 예외 처리를 위한 `GlobalExceptionHandler`를 추가하였습니다.
- 회원가입 Controller의 요청값에 `@RequestBody`를 추가하였습니다.
- 폴더 구조 및 코드를 정리하였습니다.

### 관련 이슈

> 본 PR이 머지되면 자동으로 닫을 이슈를 [형식](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)에 따라 작성하고,
> 종료하지 않고 연결만 한다면 예약어 없이 작성해주세요.

- close #22 
