### PR TITLE
fix: 사용자별 관심 매물 조회 반환값 순서 수

### DIFF
--- a/src/main/java/com/aptzip/interestDeal/dto/response/SaleListResponse.java
+++ b/src/main/java/com/aptzip/interestDeal/dto/response/SaleListResponse.java
@@ -9,10 +9,10 @@ public record SaleListResponse(
         String gugunName,
         String dongName,
         String jibun,
-        Integer dealAmount,
         Integer dealYear,
         Integer dealMonth,
         Integer dealDay,
+        Integer dealAmount,
         Double latitude,
         Double longitude) {
 }

--- a/src/main/java/com/aptzip/interestDeal/dto/response/SaleListResponse.java
+++ b/src/main/java/com/aptzip/interestDeal/dto/response/SaleListResponse.java
@@ -3,12 +3,16 @@ package com.aptzip.interestDeal.dto.response;
 public record SaleListResponse(
         String saleUuid,
         Integer no,
+        String aptSeq,
         String aptNm,
         String sidoName,
         String gugunName,
         String dongName,
         String jibun,
         Integer dealAmount,
+        Integer dealYear,
+        Integer dealMonth,
+        Integer dealDay,
         Double latitude,
         Double longitude) {
 }

--- a/src/main/java/com/aptzip/interestDeal/respository/InterestSaleRepositiory.java
+++ b/src/main/java/com/aptzip/interestDeal/respository/InterestSaleRepositiory.java
@@ -16,11 +16,15 @@ public interface InterestSaleRepositiory extends JpaRepository<InterestSale, Str
     @Query("SELECT " +
             "  i.saleUuid, "+
             "  i.houseDeal.no, "+
+            "  h.houseInfo.aptSeq ," +
             "  i.aptNm, " +
             "  i.sidoName, " +
             "  i.gugunName, " +
             "  i.dongName, " +
             "  i.jibun, " +
+            "  i.houseDeal.dealYear, "+
+            "  i.houseDeal.dealMonth,"+
+            "  i.houseDeal.dealDay,"+
             "  h.dealAmount, " +
             "  i.latitude,  " +
             "  i.longitude " +

--- a/src/main/java/com/aptzip/interestDeal/service/InterestSaleService.java
+++ b/src/main/java/com/aptzip/interestDeal/service/InterestSaleService.java
@@ -30,14 +30,18 @@ public class InterestSaleService {
                 .map(result -> new SaleListResponse(
                         (String) result[0],   //saleUuid
                         (Integer) result[1], //no
-                        (String) result[2],  // aptNm
-                        (String) result[3],  // sidoName
-                        (String) result[4],  // gugunName
-                        (String) result[5],  // dongName
-                        (String) result[6],  // jibun
-                        (Integer) result[7], // dealAmount
-                        (Double) result[8], //latitude
-                        (Double) result[9]   //longitude
+                        (String) result[2], //apt_seq
+                        (String) result[3],  // aptNm
+                        (String) result[4],  // sidoName
+                        (String) result[5],  // gugunName
+                        (String) result[6],  // dongName
+                        (String) result[7],  // jibun
+                        (Integer) result[8], //dealYear
+                        (Integer) result[9], //dealMonth
+                        (Integer) result[10], //dealDay
+                        (Integer) result[11], // dealAmount
+                        (Double) result[12], //latitude
+                        (Double) result[13]   //longitude
                 ))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### 중요 변경 사항 🚨

> 하기 사항이 변경된 경우 체크해주세요.

- [ ] DB 스키마가 수정되었습니다.
- [ ] 환경변수 파일이 추가/삭제/수정되었습니다.
- [ ] 의존성이 추가/삭제/수정되었습니다.

### 작업 내용 🧑🏻‍💻

> 기능 추가, 버그 수정 등 작업 내용을 작성해주세요.

- 사용자별 관심 매물 조회 시 반환값의 순서를 수정하였습니다.

### 관련 이슈

> 본 PR이 머지되면 자동으로 닫을 이슈를 [형식](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)에 따라 작성하고,
> 종료하지 않고 연결만 한다면 예약어 없이 작성해주세요.

- close #45 
